### PR TITLE
Optimised reloading of server sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,22 +32,8 @@ if (process.env.NODE_ENV === 'production') {
   // Allow client to be notified of changes to sources.
   app.use(require('webpack-hot-middleware')(compiler))
 
-  // Watch for FS changes in ./app and clear cached modules when a change occurs,
-  // thus effectively reloading the file on a subsequent request.
-  const appPath = path.join(__dirname, 'app')
-  const watcher = require('chokidar').watch(appPath)
-  watcher.on('ready', function() {
-    // TODO See if this can be optimsed to reload less files.
-    //      Basically need to know dependency graph of modules, maybe flow can help?
-    watcher.on('all', function() {
-      // console.log(`Clearing module cache in: ${appPath}`)
-      Object.keys(require.cache).forEach(function(id: string) {
-        if (id.startsWith(appPath)) {
-          delete require.cache[id]
-        }
-      })
-    })
-  })
+  // Reload server-side modules when they change.
+  require('./lib/dev/reloadModules')(path.join(__dirname, 'app'))
 
   // In case of an uncaught exception show it to the user and proceed, rather than exiting the process.
   // NOTE: This is a bad thing when it comes to concurrency, basically you can’t have 2 requests at the same time.

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'production') {
 } else {
   app.use(morgan('dev'))
 
-  // Long stack traces
+  // Long symbolicated stack traces
   require('longjohn')
 
   const webpack = require('webpack')

--- a/lib/dev/reloadModules.js
+++ b/lib/dev/reloadModules.js
@@ -1,0 +1,45 @@
+// @flow
+
+import chokidar from 'chokidar'
+
+// There’s no interface declaration for the Module module
+// $FlowFixMe
+import Module from 'module'
+
+module.exports = (root: string) => {
+  const inclusionMap: { [key: string]: Set<string> } = {}
+
+  // Overload Module._load
+  const _load = Module._load
+  Module._load = function(request, parent, isMain) {
+    const result = _load.apply(this, arguments)
+    const filename = Module._resolveFilename(request, parent, isMain)
+    if (filename.startsWith(root) && parent.id.startsWith(root)) {
+      const inclusions = inclusionMap[filename] || new Set()
+      inclusions.add(parent.id)
+      inclusionMap[filename] = inclusions
+    }
+    return result
+  }
+
+  const inclusionsResolver = (filename) => {
+    const inclusions = [...inclusionMap[filename] || []]
+    return inclusions.map(inclusionsResolver).reduce((a, b) => a.concat(b), inclusions)
+  }
+
+  // Watch for FS changes, find the modules that depend on the changed module, and reload all of those.
+  const watcher = chokidar.watch(root)
+  watcher.on('ready', function() {
+    watcher.on('all', function(type, filename) {
+      const inclusions = inclusionsResolver(filename)
+      inclusions.forEach(id => {
+        delete require.cache[id]
+        delete inclusionMap[id]
+        for (const key in inclusionMap) {
+          inclusionMap[key].delete(id)
+        }
+      })
+      inclusions.forEach(require)
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "flow-bin": "^0.37.4",
     "getstorybook": "^1.7.0",
     "jest": "^18.0.0",
-    "longjohn": "^0.2.11",
+    "longjohn": "alloy/longjohn#update-source-map-support",
     "react-hot-loader": "^1.3.1",
     "react-storybooks-relay-container": "^1.0.1",
     "storyshots": "orta/storyshots#49bfe52",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,11 +3537,11 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-longjohn@^0.2.11:
+longjohn@alloy/longjohn#update-source-map-support:
   version "0.2.11"
-  resolved "https://registry.yarnpkg.com/longjohn/-/longjohn-0.2.11.tgz#83736a15ae5f48711b625153e98012f2de659e69"
+  resolved "https://codeload.github.com/alloy/longjohn/tar.gz/60436603f90e26d173cd876b6e204d9cde976a01"
   dependencies:
-    source-map-support "0.3.2"
+    source-map-support "0.3.2 - 1.0.0"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.3.0"
@@ -5061,23 +5061,11 @@ source-list-map@^0.1.4, source-list-map@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.7.tgz#d4b5ce2a46535c72c7e8527c71a77d250618172e"
 
-source-map-support@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.2.tgz#737d5c901e0b78fdb53aca713d24f23ccbb10be1"
-  dependencies:
-    source-map "0.1.32"
-
-source-map-support@^0.4.2:
+"source-map-support@0.3.2 - 1.0.0", source-map-support@^0.4.2:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
   dependencies:
     source-map "^0.5.3"
-
-source-map@0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"


### PR DESCRIPTION
Ended up rolling my own, as e.g. the haste lib is about resolving dependencies of a module, whereas we need to know the modules that depend on the changed file instead (inclusions).